### PR TITLE
Remove extra line from output when running in bootstrap mode (fixes #6).

### DIFF
--- a/src/BootstrapSample.cpp
+++ b/src/BootstrapSample.cpp
@@ -98,7 +98,6 @@ void BootstrapSample::WriteBootstrap(const std::vector<std::string> &cluster_ind
       out << relative_abundances[j][i] << (j == iters ? '\n' : '\t');
     }
   }
-  out << std::endl;
   if (!outfile.empty()) {
     of.close();
   }


### PR DESCRIPTION
Removed an extra empty line from the relative abundances output when running in bootstrap mode with the `--iters` option. The outputs from bootstrap and normal modes are now consistent with the exception of the extra columns from the bootstrap runs.

This pull request resolves #6.