### PR TITLE
Support Themisto v2.0.0 and newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,24 @@ build_index and pseudoalign commands from Themisto. The --mem-megas
 option controls the maximum amount of RAM used in constructing the
 index (if the limit is exceeded, Themisto will use disk storage), and
 --n-threads the number of threads to use.
+
+__Themisto version v2.0.0 or newer__
+
+```
+## Build the Themisto index without clustering
+mkdir themisto_index
+mkdir tmp
+
+## Index using at most 2048 megabytes of memory and 2 threads.
+themisto build -k 31 -i example.fasta -o themisto_index/index --temp-dir tmp --mem-megas 2048 --n-threads 2
+
+## Pseudoalign reads using 2 threads
+themisto pseudoalign -q 215_1.fastq.gz -o 215_1_alignment.txt -i themisto_index/index --temp-dir tmp --n-threads 2 --rc --sort-output
+themisto pseudoalign -q 215_2.fastq.gz -o 215_2_alignment.txt -i themisto_index/index --temp-dir tmp --n-threads 2 --rc --sort-output
+```
+
+__Themisto versions v0.1.1 to v1.2.0__
+
 ```
 ## Build the Themisto index without clustering
 mkdir themisto_index
@@ -150,8 +168,9 @@ file in the folder mSWEEP was run in. If the '-o' option is not
 specified, the abundances will print to cout.
 
 Note that supplying the --themisto-index is optional but highly
-recommended (running mSWEEP without this option will *not* validate
-the input 'clustering.txt' and may cause undefined behaviour).
+recommended for Themisto versions v1.2.0 and older (running mSWEEP
+without this option will *not* validate the input 'clustering.txt' and
+may cause undefined behaviour).
 
 ### Experimental usage
 #### Bootstrapping confidence intervals
@@ -188,6 +207,22 @@ group as if the read aligned to all sequences in the group. This
 approach will in most cases produce different results than the recommended one, but will
 reduce the RAM, CPU, and disk space requirements for running Themisto
 and mSWEEP.
+
+__Themisto version v2.0.0 or newer__
+
+```
+## Build grouped Themisto index
+mkdir themisto_grouped_index
+mkdir tmp
+themisto build -k 31 -i example.fasta -c clustering.txt -o themisto_grouped_index --temp-dir tmp
+
+## Pseudoalign reads
+themisto pseudoalign -query-file 215_1.fastq.gz -o 215_1_alignment.txt -i themisto_grouped_index --rc --temp-dir tmp --sort-output
+themisto pseudoalign -query-file 215_2.fastq.gz -o 215_2_alignment.txt -i themisto_grouped_index --rc --temp-dir tmp --sort-output
+```
+
+__Themisto versions v0.1.1 to v1.2.0__
+
 ```
 ## Build grouped Themisto index
 mkdir themisto_grouped_index
@@ -197,7 +232,11 @@ build_index --k 31 --input-file example.fasta --color-file clustering.txt --inde
 ## Pseudoalign reads
 pseudoalign --query-file 215_1.fastq.gz --outfile 215_1_alignment.txt --rc --index-dir themisto_grouped_index --temp-dir tmp --sort-output
 pseudoalign --query-file 215_2.fastq.gz --outfile 215_2_alignment.txt --rc --index-dir themisto_grouped_index --temp-dir tmp --sort-output
+```
 
+##### Using embedded colors with mSWEEP
+
+```
 ## Extract unique cluster indicators from the clustering.txt file
 awk '!seen[$0]++' clustering.txt > unique_clusters.txt
 
@@ -221,7 +260,9 @@ You should see that roughly 90% of the reads are assigned to group "clust2".
 # General pipeline
 ## Preprocessing
 - Obtain a set of reference sequences. (See the steps under Usage -> Reference data)
-- Index the reference sequences for pseudoalignment with Themisto:
+- Index the reference sequences for pseudoalignment with Themisto (__v2.0.0 or newer__):
+> themisto build -k 31 -i reference_sequences.fasta -o themisto_index --temp-dir tmp
+- Index the reference sequences for pseudoalignment with Themisto (__v0.1.1 to v1.2.0__):
 > build_index --k 31 --input-file reference_sequences.fasta --auto-colors --index-dir themisto_index --temp-dir tmp
 - ... or with kallisto
 > kallisto pseudo -i reference_kmi reference_sequences.fasta
@@ -302,6 +343,17 @@ which will instruct mSWEEP to estimate relative abundances for both groupings.
 
 ## Analysing reads (with Themisto)
 - Pseudomap paired-end reads:
+
+__Themisto version v2.0.0 or newer__
+
+```
+mkdir tmp
+themisto pseudoalign -i themisto_index -q reads_1.fastq.gz -o reads_1_out.txt --temp-dir tmp --rc --sort-output
+themisto pseudoalign -i themisto_index -q reads_2.fastq.gz -o reads_2_out.txt --temp-dir tmp --rc --sort-output
+```
+
+__Themisto versions v0.1.1 to v1.2.0__
+
 ```
 mkdir tmp
 pseudoalign --index-dir themisto_index --query-file reads_1.fastq.gz --outfile reads_1_out.txt --temp-dir tmp --rc --sort-output
@@ -356,7 +408,7 @@ mSWEEP accepts the following flags:
 	--themisto-mode <PairedEndMergeMode>
 	How to merge Themisto pseudoalignments for paired-end reads	(intersection or union, default: intersection).
 	--themisto-index <ThemistoIndex>
-	Path to the Themisto index the pseudoalignment was performed against (optional).
+	Path to the Themisto index the pseudoalignment was performed against (optional, Themisto v1.2.0 or older only).
 
 	--fasta <ReferenceSequences>
 	Path to the reference sequences the pseudoalignment index was constructed from (optional)

--- a/src/Reference.cpp
+++ b/src/Reference.cpp
@@ -9,9 +9,9 @@
 void Reference::verify_themisto_index(cxxio::In &themisto_index) const {
   uint32_t lines_in_grouping = themisto_index.count_lines<uint32_t>();
   if (lines_in_grouping > this->n_refs) {
-    throw std::runtime_error("pseudoalignment has more reference sequences than the grouping.");
+    throw std::domain_error("pseudoalignment has more reference sequences than the grouping.");
   } else if (lines_in_grouping < this->n_refs) {
-    throw std::runtime_error("grouping has more reference sequences than the pseudoalignment.");
+    throw std::domain_error("grouping has more reference sequences than the pseudoalignment.");
   }
 }
 

--- a/src/mSWEEP.cpp
+++ b/src/mSWEEP.cpp
@@ -70,14 +70,20 @@ int main (int argc, char *argv[]) {
       ReadPseudoalignment(args.infiles, reference.get_n_refs(), samples, args.bootstrap_mode);
     } else {
       if (!args.themisto_index_path.empty()) {
-	cxxio::In themisto_index(args.themisto_index_path + "/coloring-names.txt");
-	reference.verify_themisto_index(themisto_index);
+	try {
+	  cxxio::In themisto_index(args.themisto_index_path + "/coloring-names.txt");
+	  reference.verify_themisto_index(themisto_index);
+	} catch (const std::runtime_error &e) {
+	  throw std::runtime_error("--themisto-index flag is not supported for Themisto v2.0.0 or newer:\n" + std::string(e.what()));
+	} catch (const std::domain_error &e) {
+	  throw e;
+	}
       }
       ReadPseudoalignment(args.tinfile1, args.tinfile2, args.themisto_merge_mode, args.bootstrap_mode, reference.get_n_refs(), samples);
     }
 
     std::cerr << "  read " << (args.batch_mode ? samples.size() : samples[0]->num_ecs()) << (args.batch_mode ? " samples from the batch" : " unique alignments") << std::endl;
-  } catch (std::runtime_error &e) {
+  } catch (const std::exception &e) {
     std::cerr << "Reading the input files failed:\n  ";
     std::cerr << e.what();
     std::cerr << "\nexiting" << std::endl;

--- a/src/parse_arguments.cpp
+++ b/src/parse_arguments.cpp
@@ -33,7 +33,7 @@ void PrintHelpMessage() {
 	    << "\tPath to the Themisto index the pseudoalignment was performed against (optional).\n"
 	    << "\n"
     	    << "\t--fasta <ReferenceSequences>\n"
-	    << "\tPath to the reference sequences the pseudoalignment index was constructed from (optional)\n"
+	    << "\tPath to the reference sequences the pseudoalignment index was constructed from (optional, Themisto v1.2.0 or older only)\n"
     	    << "\t--groups-list <groupIndicatorsList>\n"
 	    << "\tTable containing names of the reference sequences (1st column) and their group assignments (2nd column) (optional)\n"
     	    << "\t--groups-delimiter <groupIndicatorsListDelimiter>\n"


### PR DESCRIPTION
Themisto's command line interface and index output format will change with the v2.0.0 release (see [Themisto 87ad71f8](https://github.com/algbio/themisto/tree/87ad71f8249b51442c0e99219002686c52f0676a)). This pull request adds the following changes for compatibility with both the new and the old versions:
- Changed the `--themisto-index` argument so that the program will abort with an error telling the user to rerun mSWEEP without `--themisto-index` if Themisto v2.0.0 index format is detected.
- Updated documentation with usage instructions for both Themisto <=v1.2..0 and >=v2.0.0.

Please wait until the release of Themisto v2.0.0 before merging this pull request.