### PR TITLE
Add macOS-arm64 and macOS-x86_64 prebuilt binaries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ mSWEEP --help
 ## Precompiled binaries
 Precompiled binaries are available for
 * [Linux x86\_64 (mSWEEP-v2.0.0)](https://github.com/PROBIC/mSWEEP/releases/download/v2.0.0/mSWEEP_linux-v2.0.0.tar.gz).
+* [macOS arm64 (mSWEEP-v2.0.0)](https://github.com/PROBIC/mSWEEP/releases/download/v2.0.0/mSWEEP_macOS-arm64-v2.0.0.tar.gz)
+* [macOS x86\_64 (mSWEEP-v2.0.0)](https://github.com/PROBIC/mSWEEP/releases/download/v2.0.0/mSWEEP_macOS-x86_64-v2.0.0.tar.gz)
 
 ## Compiling from source
 ### Requirements


### PR DESCRIPTION
Now building for macOS again using https://github.com/shepherdjerred/macos-cross-compiler.