### PR TITLE
Refactor input reading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,11 +168,6 @@ endif()
 include_directories(${CMAKE_BXZSTR_HEADERS})
 
 ## Check dependencies and download them if not given
-## BitMagic
-set(CMAKE_BITMAGIC_HEADERS ${CMAKE_CURRENT_BINARY_DIR}/external/mGEMS/external/telescope/external/BitMagic-7.12.3/src/)
-include_directories(${CMAKE_BITMAGIC_HEADERS})
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/external/mGEMS/external/telescope/include)
-
 ## cxxio
 if (DEFINED CMAKE_CXXIO_HEADERS)
   message(STATUS "cxxio headers provided in: ${CMAKE_CXXIO_HEADERS}")
@@ -237,9 +232,18 @@ else()
   set_target_properties(alignment-writer PROPERTIES EXCLUDE_FROM_ALL 1)
   set(CMAKE_ALIGNMENT_WRITER_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/external/alignment-writer/include)
   set(CMAKE_ALIGNMENT_WRITER_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/lib/libalignment-writer.a)
+  set(CMAKE_BITMAGIC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/external/alignment-writer/external/BitMagic-7.12.3/src/)
 endif()
 include_directories(${CMAKE_ALIGNMENT_WRITER_HEADERS})
 target_link_libraries(mSWEEP ${CMAKE_ALIGNMENT_WRITER_LIBRARY})
+
+## BitMagic
+if (DEFINED CMAKE_BITMAGIC_HEADERS)
+  message(STATUS "BitMagic headers provided in: ${CMAKE_BITMAGIC_HEADERS}")
+else()
+  message(FATAL_ERROR "Provide BitMagic C++ headers with -DCMAKE_BITMAGIC_HEADERS")
+endif()
+include_directories(${CMAKE_BITMAGIC_HEADERS})
 
 ## seamat
 if (DEFINED CMAKE_SEAMAT_HEADERS)
@@ -252,6 +256,7 @@ else()
     SOURCE_DIR        "${CMAKE_CURRENT_SOURCE_DIR}/external/seamat"
     BUILD_IN_SOURCE   0
     CMAKE_ARGS        -D CMAKE_BUILD_TESTS=0
+                      -D CMAKE_BITMAGIC_HEADERS=${CMAKE_BITMAGIC_HEADERS}
     BUILD_COMMAND     ""
     CONFIGURE_COMMAND ""
     INSTALL_COMMAND   ""
@@ -301,7 +306,7 @@ if (DEFINED CMAKE_MGEMS_LIBRARY AND DEFINED CMAKE_MGEMS_HEADERS)
 else()
   FetchContent_Declare(mGEMS
     GIT_REPOSITORY    https://github.com/PROBIC/mGEMS.git
-    GIT_TAG           v1.3.0
+    GIT_TAG           v1.3.3
     PREFIX            "external"
     SOURCE_DIR        "${CMAKE_CURRENT_SOURCE_DIR}/external/mGEMS"
     BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/external/mGEMS"
@@ -310,9 +315,8 @@ else()
 		    -D CMAKE_CXXARGS_HEADERS=${CMAKE_CXXARGS_HEADERS}
 		    -D CMAKE_CXXIO_HEADERS=${CMAKE_CXXIO_HEADERS}
 		    -D CMAKE_ALIGNMENT_WRITER_HEADERS=${CMAKE_ALIGNMENT_WRITER_HEADERS}
-		    -D CMAKE_BITMAGIC_HEADERS=${CMAKE_CURRENT_BINARY_DIR}/external/telescope/external/BitMagic-7.12.3/src
+		    -D CMAKE_BITMAGIC_HEADERS=${CMAKE_BITMAGIC_HEADERS}
 		    -D CMAKE_SEAMAT_HEADERS=${CMAKE_SEAMAT_HEADERS}
-		    -D CMAKE_TELESCOPE_HEADERS=${CMAKE_TELESCOPE_HEADERS}
 		    -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
 		    -D "CMAKE_C_FLAGS=${CMAKE_C_FLAGS}"
 		    -D "CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
@@ -321,13 +325,13 @@ else()
     INSTALL_COMMAND   ""
     )
   FetchContent_MakeAvailable(mGEMS)
-  add_dependencies(mGEMS telescope libalignmentwriter)
+  add_dependencies(mGEMS libalignmentwriter)
   add_dependencies(mSWEEP libmgems)
   set_target_properties(mGEMS PROPERTIES EXCLUDE_FROM_ALL 1)
-  set(CMAKE_MGEMS_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/external/mGEMS/include)
+  set(CMAKE_MGEMS_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/external/mGEMS/include ${CMAKE_CURRENT_BINARY_DIR}/external/mGEMS/include)
   set(CMAKE_MGEMS_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/external/mGEMS/lib/libmgems.a)
 endif()
-target_link_libraries(mSWEEP ${CMAKE_MGEMS_LIBRARY} ${CMAKE_TELESCOPE_LIBRARY} ${CMAKE_ALIGNMENT_WRITER_LIBRARY})
+target_link_libraries(mSWEEP ${CMAKE_MGEMS_LIBRARY} ${CMAKE_ALIGNMENT_WRITER_LIBRARY})
 include_directories(${CMAKE_MGEMS_HEADERS})
 
 include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,11 @@ endif()
 include_directories(${CMAKE_BXZSTR_HEADERS})
 
 ## Check dependencies and download them if not given
+## BitMagic
+set(CMAKE_BITMAGIC_HEADERS ${CMAKE_CURRENT_BINARY_DIR}/external/mGEMS/external/telescope/external/BitMagic-7.12.3/src/)
+include_directories(${CMAKE_BITMAGIC_HEADERS})
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/external/mGEMS/external/telescope/include)
+
 ## cxxio
 if (DEFINED CMAKE_CXXIO_HEADERS)
   message(STATUS "cxxio headers provided in: ${CMAKE_CXXIO_HEADERS}")
@@ -235,42 +240,6 @@ else()
 endif()
 include_directories(${CMAKE_ALIGNMENT_WRITER_HEADERS})
 target_link_libraries(mSWEEP ${CMAKE_ALIGNMENT_WRITER_LIBRARY})
-
-## telescope
-if (DEFINED CMAKE_TELESCOPE_LIBRARY AND DEFINED CMAKE_TELESCOPE_HEADERS)
-  message(STATUS "telescope headers provided in: ${CMAKE_TELESCOPE_HEADERS}")
-  message(STATUS "telescope library provided in: ${CMAKE_TELESCOPE_LIBRARY}")
-else()
-  FetchContent_Declare(telescope
-    GIT_REPOSITORY    https://github.com/tmaklin/telescope.git
-    GIT_TAG           v0.7.2
-    PREFIX            "external"
-    SOURCE_DIR        "${CMAKE_CURRENT_SOURCE_DIR}/external/telescope"
-    BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/external/telescope"
-    BUILD_IN_SOURCE   0
-    CMAKE_ARGS      -D CMAKE_BXZSTR_HEADERS=${CMAKE_BXZSTR_HEADERS}
-		    -D CMAKE_CXXARGS_HEADERS=${CMAKE_CXXARGS_HEADERS}
-		    -D CMAKE_CXXIO_HEADERS=${CMAKE_CXXIO_HEADERS}
-		    -D CMAKE_ALIGNMENT_WRITER_HEADERS=${CMAKE_ALIGNMENT_WRITER_HEADERS}
-		    -D CMAKE_ALIGNMENT_WRITER_LIBRARY=${CMAKE_ALIGNMENT_WRITER_LIBRARY}
-		    -D CMAKE_BITMAGIC_HEADERS=${CMAKE_CURRENT_SOURCE_DIR}/external/telescope/external/BitMagic-7.12.3/src
-		    -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-		    -D "CMAKE_C_FLAGS=${CMAKE_C_FLAGS}"
-		    -D "CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
-		    -D "CMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
-		    -D "CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
-    INSTALL_COMMAND   ""
-    )
-  FetchContent_MakeAvailable(telescope)
-  add_dependencies(telescope libalignmentwriter)
-  add_dependencies(mSWEEP telescope)
-  set_target_properties(telescope PROPERTIES EXCLUDE_FROM_ALL 1)
-  set(CMAKE_TELESCOPE_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/external/telescope/include)
-  set(CMAKE_TELESCOPE_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/lib/libtelescope.a)
-  set(CMAKE_BITMAGIC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/external/telescope/external/BitMagic-7.12.3/src)
-endif()
-include_directories(${CMAKE_TELESCOPE_HEADERS} ${CMAKE_BITMAGIC_HEADERS})
-target_link_libraries(mSWEEP ${CMAKE_TELESCOPE_LIBRARY})
 
 ## seamat
 if (DEFINED CMAKE_SEAMAT_HEADERS)

--- a/include/Likelihood.hpp
+++ b/include/Likelihood.hpp
@@ -119,19 +119,14 @@ private:
 #endif
 
     // This double loop is currently the slowest part in the input reading
-    std::vector<bm::sparse_vector<V, bm::bvector<>>> local_counts(n_threads);
+    std::vector<size_t> group_counts(num_ecs*n_groups, 0);
 #pragma omp parallel for schedule(static)
     for (size_t i = 0; i < num_ecs; ++i) {
 	for (size_t j = 0; j < n_targets; ++j) {
 	    if (alignment(i, j)) {
-		local_counts[omp_get_thread_num()].inc(alignment.get_groups()[j]*num_ecs + i);
+		++group_counts[alignment.get_groups()[j]*num_ecs + i];
 	    }
 	}
-    }
-
-    bm::sparse_vector<V, bm::bvector<>> group_counts = std::move(local_counts[0]);
-    for (size_t i = 1; i < n_threads; ++i) {
-	group_counts.merge(local_counts[i]);
     }
 
     bool mask_groups = min_hits > 0;

--- a/include/Likelihood.hpp
+++ b/include/Likelihood.hpp
@@ -140,7 +140,7 @@ private:
 #pragma omp parallel for schedule(static) reduction(vec_size_t_plus:group_hit_counts)
 	for (size_t i = 0; i < num_ecs; ++i) {
 	    for (size_t j = 0; j < n_groups; ++j) {
-		group_hit_counts[j] += group_counts[i*n_groups + j] * alignment.reads_in_ec(i);
+		group_hit_counts[j] += (group_counts[i*n_groups + j] > 0) * alignment.reads_in_ec(i);
 	    }
 	}
 

--- a/include/Likelihood.hpp
+++ b/include/Likelihood.hpp
@@ -124,7 +124,7 @@ private:
     for (size_t i = 0; i < num_ecs; ++i) {
 	for (size_t j = 0; j < n_targets; ++j) {
 	    if (alignment(i, j)) {
-		local_counts[omp_get_thread_num()].inc(alignment.get_groups()[j]*num_ecs + i);
+		local_counts[omp_get_thread_num()].inc((size_t)((size_t)alignment.get_groups()[j]*num_ecs) + i);
 	    }
 	}
     }

--- a/include/Likelihood.hpp
+++ b/include/Likelihood.hpp
@@ -119,14 +119,19 @@ private:
 #endif
 
     // This double loop is currently the slowest part in the input reading
-    std::vector<size_t> group_counts(num_ecs*n_groups, 0);
+    std::vector<bm::sparse_vector<V, bm::bvector<>>> local_counts(n_threads);
 #pragma omp parallel for schedule(static)
     for (size_t i = 0; i < num_ecs; ++i) {
 	for (size_t j = 0; j < n_targets; ++j) {
 	    if (alignment(i, j)) {
-		++group_counts[alignment.get_groups()[j]*num_ecs + i];
+		local_counts[omp_get_thread_num()].inc(alignment.get_groups()[j]*num_ecs + i);
 	    }
 	}
+    }
+
+    bm::sparse_vector<V, bm::bvector<>> group_counts = std::move(local_counts[0]);
+    for (size_t i = 1; i < n_threads; ++i) {
+	group_counts.merge(local_counts[i]);
     }
 
     bool mask_groups = min_hits > 0;

--- a/include/Likelihood.hpp
+++ b/include/Likelihood.hpp
@@ -110,13 +110,28 @@ private:
     size_t num_ecs = alignment.n_ecs();
     size_t n_targets = alignment.get_n_targets();
 
-    bm::sparse_vector<V, bm::bvector<>> group_counts;
+    size_t n_threads = 1;
+#if defined(MSWEEP_OPENMP_SUPPORT) && (MSWEEP_OPENMP_SUPPORT) == 1
+#pragma omp parallel
+    {
+	n_threads = omp_get_num_threads();
+    }
+#endif
+
+    // This double loop is currently the slowest part in the input reading
+    std::vector<bm::sparse_vector<V, bm::bvector<>>> local_counts(n_threads);
+#pragma omp parallel for schedule(static)
     for (size_t i = 0; i < num_ecs; ++i) {
 	for (size_t j = 0; j < n_targets; ++j) {
 	    if (alignment(i, j)) {
-		group_counts.inc(alignment.get_groups()[j]*num_ecs + i);
+		local_counts[omp_get_thread_num()].inc(alignment.get_groups()[j]*num_ecs + i);
 	    }
 	}
+    }
+
+    bm::sparse_vector<V, bm::bvector<>> group_counts = std::move(local_counts[0]);
+    for (size_t i = 1; i < n_threads; ++i) {
+	group_counts.merge(local_counts[i]);
     }
 
     bool mask_groups = min_hits > 0;

--- a/include/Likelihood.hpp
+++ b/include/Likelihood.hpp
@@ -118,7 +118,7 @@ private:
 	for (size_t i = 0; i < num_ecs; ++i) {
 	    std::vector<size_t> ec_hit_counts = alignment(i);
 	    for (size_t j = 0; j < n_groups; ++j) {
-		group_hit_counts[j] += ec_hit_counts[j];
+		group_hit_counts[j] += ec_hit_counts[j] * alignment.reads_in_ec(i);
 	    }
 	}
 	for (size_t i = 0; i < n_groups; ++i) {
@@ -153,7 +153,7 @@ private:
     this->log_ec_counts.resize(alignment.n_ecs(), 0);
 #pragma omp parallel for schedule(static)
     for (size_t i = 0; i < alignment.n_ecs(); ++i) {
-      this->log_ec_counts[i] = 0.0;
+	this->log_ec_counts[i] = std::log(alignment.reads_in_ec(i));
     }
   }
 

--- a/include/Likelihood.hpp
+++ b/include/Likelihood.hpp
@@ -124,7 +124,11 @@ private:
     for (size_t i = 0; i < num_ecs; ++i) {
 	for (size_t j = 0; j < n_targets; ++j) {
 	    if (alignment(i, j)) {
+#if defined(MSWEEP_OPENMP_SUPPORT) && (MSWEEP_OPENMP_SUPPORT) == 1
 		local_counts[omp_get_thread_num()].inc((size_t)((size_t)alignment.get_groups()[j]*num_ecs) + i);
+#else
+		local_counts[0].inc((size_t)((size_t)alignment.get_groups()[j]*num_ecs) + i);
+#endif
 	    }
 	}
     }

--- a/include/Likelihood.hpp
+++ b/include/Likelihood.hpp
@@ -138,9 +138,9 @@ private:
 	std::vector<size_t> group_hit_counts(n_groups, (size_t)0);
 	// Create mask identifying groups that have at least 1 alignment
 #pragma omp parallel for schedule(static) reduction(vec_size_t_plus:group_hit_counts)
-	for (size_t i = 0; i < num_ecs; ++i) {
-	    for (size_t j = 0; j < n_groups; ++j) {
-		group_hit_counts[j] += (group_counts[i*n_groups + j] > 0) * alignment.reads_in_ec(i);
+	for (size_t j = 0; j < n_groups; ++j) {
+	    for (size_t i = 0; i < num_ecs; ++i) {
+		group_hit_counts[j] += (group_counts[j*num_ecs + i] > 0) * alignment.reads_in_ec(i);
 	    }
 	}
 

--- a/include/Sample.hpp
+++ b/include/Sample.hpp
@@ -33,7 +33,7 @@
 #include <memory>
 
 #include "Matrix.hpp"
-#include "telescope.hpp"
+#include "mSWEEP_alignment.hpp"
 
 namespace mSWEEP {
 class Sample {
@@ -47,7 +47,7 @@ private:
   std::vector<double> log_KLDs;
 
 protected:
-  void count_alignments(const telescope::Alignment &alignment);
+  void count_alignments(const mSWEEP::Alignment &alignment);
 
 public:
   // Virtual functions
@@ -111,7 +111,7 @@ private:
 public:
   PlainSample() = default;
 
-  PlainSample(const telescope::Alignment &alignment) {
+  PlainSample(const mSWEEP::Alignment &alignment) {
     this->count_alignments(alignment);
   }
 
@@ -132,7 +132,7 @@ class BinningSample : public PlainSample, public Binning {
 public:
   BinningSample() = default;
 
-  BinningSample(const telescope::Alignment &alignment) {
+  BinningSample(const mSWEEP::Alignment &alignment) {
     this->count_alignments(alignment);
     this->store_aligned_reads(alignment.get_aligned_reads());
   }
@@ -157,19 +157,19 @@ private:
   std::vector<std::vector<double>> bootstrap_results;
 
   // Set all variables required to bootstrap the ec_counts later
-  void init_bootstrap(const telescope::Alignment &alignment);
+  void init_bootstrap(const mSWEEP::Alignment &alignment);
 
 protected:
-  void construct(const telescope::Alignment &alignment, const size_t _iters, const int32_t seed, const size_t bootstrap_count=0);
+  void construct(const mSWEEP::Alignment &alignment, const size_t _iters, const int32_t seed, const size_t bootstrap_count=0);
 
 public:
   BootstrapSample() = default;
 
   // Set seed in constructor
-  BootstrapSample(const telescope::Alignment &alignment, const size_t _iters, const int32_t seed) {
+  BootstrapSample(const mSWEEP::Alignment &alignment, const size_t _iters, const int32_t seed) {
     this->construct(alignment, _iters, seed);
   }
-  BootstrapSample(const telescope::Alignment &alignment, const size_t _iters, const size_t _bootstrap_count, const int32_t seed) {
+  BootstrapSample(const mSWEEP::Alignment &alignment, const size_t _iters, const size_t _bootstrap_count, const int32_t seed) {
     this->construct(alignment, _iters, seed, _bootstrap_count);
   }
 
@@ -191,18 +191,18 @@ public:
 
 class BinningBootstrap : public BootstrapSample, public Binning {
 public:
-  BinningBootstrap(const telescope::Alignment &alignment, const size_t _iters, const int32_t seed) {
+  BinningBootstrap(const mSWEEP::Alignment &alignment, const size_t _iters, const int32_t seed) {
     this->construct(alignment, _iters, seed);
     this->store_aligned_reads(alignment.get_aligned_reads());
   }
-  BinningBootstrap(const telescope::Alignment &alignment, const size_t _iters, const size_t _bootstrap_count, const int32_t seed) {
+  BinningBootstrap(const mSWEEP::Alignment &alignment, const size_t _iters, const size_t _bootstrap_count, const int32_t seed) {
     this->construct(alignment, _iters, seed, _bootstrap_count);
     this->store_aligned_reads(alignment.get_aligned_reads());
   }
 
 };
 
-void ConstructSample(const telescope::Alignment &alignment, const size_t bootstrap_iters, const size_t bootstrap_count, const size_t bootstrap_seed, const bool bin_reads, std::unique_ptr<Sample> &sample);
+void ConstructSample(const mSWEEP::Alignment &alignment, const size_t bootstrap_iters, const size_t bootstrap_count, const size_t bootstrap_seed, const bool bin_reads, std::unique_ptr<Sample> &sample);
 
 }
 

--- a/include/mSWEEP_alignment.hpp
+++ b/include/mSWEEP_alignment.hpp
@@ -225,6 +225,8 @@ public:
 	return this->ec_read_ids;
     }
 
+    const std::vector<uint32_t>& reads_assigned_to_ec(size_t ec_id) const { return this->ec_read_ids[ec_id]; }
+
     template <typename T>
     void add_groups(const std::vector<T> &grouping) {
 	size_t _n_groups = 0;

--- a/include/mSWEEP_alignment.hpp
+++ b/include/mSWEEP_alignment.hpp
@@ -33,6 +33,7 @@
 #include <fstream>
 #include <sstream>
 #include <unordered_map>
+#include <map>
 
 namespace mSWEEP {
 class Alignment {
@@ -161,7 +162,7 @@ public:
 	    }
 	}
 
-	std::unordered_map<size_t, std::vector<uint32_t>> map;
+	std::map<size_t, std::vector<uint32_t>> map;
 	for (size_t i = 0; i < n_threads; ++i) {
 	    for (auto kv : mymap[i]) {
 		auto got = map.find(kv.first);

--- a/include/mSWEEP_alignment.hpp
+++ b/include/mSWEEP_alignment.hpp
@@ -32,7 +32,6 @@
 
 #include <fstream>
 #include <sstream>
-#include <iostream>
 #include <unordered_map>
 
 namespace mSWEEP {
@@ -52,19 +51,6 @@ public:
     }
 
     void ReadPlaintextLine(const size_t n_targets, std::string &line, bm::bvector<>::bulk_insert_iterator &it) {
-	// telescope::ReadPlaintextLine
-	//
-	// Reads a line in a plaintext alignment file from Themisto
-	// (https://github.com/algbio/themisto) into the bm::bvector<> `it`
-	// inserts to.
-	//
-	// Input:
-	//   `n_targets`: number of pseudoalignment targets (reference
-	//                sequences). It's not possible to infer this from the Themisto
-	//                file format so has to be provided separately.
-	//   `line`: the line from the alignment file to read in.
-	//   `it`: insert iterator to the bm::bvector<> variable for storing the alignment.
-	//
 	std::string part;
 	std::stringstream partition(line);
 
@@ -79,24 +65,6 @@ public:
     }
 
     size_t ReadPlaintextAlignment(const size_t n_targets, std::string &line, std::istream *stream, bm::bvector<> *ec_configs) {
-	// telescope::ReadPlaintextAlignment
-	//
-	// Reads a plaintext alignment file from Themisto
-	// (https://github.com/algbio/themisto) into `*ec_configs` and
-	// return the number of reads in the file (both unaligned and
-	// aligned).
-	//
-	// Input:
-	//   `n_targets`: number of pseudoalignment targets (reference
-	//                sequences). It's not possible to infer this from the Themisto
-	//                file format so has to be provided separately.
-	//   `line`: read each line into this variable.
-	//     NOTE: the contents of the *first* line should already be stored in this variable.
-	//   `stream`: pointer to an istream opened on the pseudoalignment file.
-	//   `ec_configs`: pointer to the output variable that will contain the alignment.
-	// Output:
-	//   `n_reads`: total number of reads in the pseudoalignment (unaligned + aligned).
-	//
 	bm::bvector<>::bulk_insert_iterator it(*ec_configs); // Bulk insert iterator buffers the insertions
 
 	size_t n_reads = 1;
@@ -173,7 +141,6 @@ public:
 	    n_threads = omp_get_num_threads();
 	}
 #endif
-
 
 	std::vector<std::unordered_map<size_t, std::pair<size_t, size_t>>> mymap(n_threads);
 	std::vector<std::vector<size_t>> my_ec_counts(n_threads);

--- a/include/mSWEEP_alignment.hpp
+++ b/include/mSWEEP_alignment.hpp
@@ -1,0 +1,201 @@
+// mSWEEP: Estimate abundances of reference lineages in DNA sequencing reads.
+//
+// MIT License
+//
+// Copyright (c) 2023 Probabilistic Inference and Computational Biology group @ UH
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+#ifndef MSWEEP_ALIGNMENT_HPP
+#define MSWEEP_ALIGNMENT_HPP
+
+#include "bm64.h"
+#include "unpack.hpp"
+
+#include <fstream>
+#include <sstream>
+#include <iostream>
+
+namespace mSWEEP {
+class Alignment {
+private:
+    bm::bvector<> bits;
+    size_t n_targets;
+    size_t n_queries;
+    std::vector<size_t> group_indicators;
+    size_t n_groups;
+
+public:
+    Alignment(size_t _n_targets) {
+	this->n_targets = _n_targets;
+    }
+
+    void ReadPlaintextLine(const size_t n_targets, std::string &line, bm::bvector<>::bulk_insert_iterator &it) {
+	// telescope::ReadPlaintextLine
+	//
+	// Reads a line in a plaintext alignment file from Themisto
+	// (https://github.com/algbio/themisto) into the bm::bvector<> `it`
+	// inserts to.
+	//
+	// Input:
+	//   `n_targets`: number of pseudoalignment targets (reference
+	//                sequences). It's not possible to infer this from the Themisto
+	//                file format so has to be provided separately.
+	//   `line`: the line from the alignment file to read in.
+	//   `it`: insert iterator to the bm::bvector<> variable for storing the alignment.
+	//
+	std::string part;
+	std::stringstream partition(line);
+
+	// First column is read id (0-based indexing).
+	std::getline(partition, part, ' ');
+	size_t read_id = std::stoul(part);
+
+	// Next columns contain the target sequence id (0-based indexing).
+	while (std::getline(partition, part, ' ')) {
+	    *it = read_id*n_targets + std::stoul(part); // set bit `n_reads*n_refs + std::stoul(part)` as true
+	}
+    }
+
+    size_t ReadPlaintextAlignment(const size_t n_targets, std::string &line, std::istream *stream, bm::bvector<> *ec_configs) {
+	// telescope::ReadPlaintextAlignment
+	//
+	// Reads a plaintext alignment file from Themisto
+	// (https://github.com/algbio/themisto) into `*ec_configs` and
+	// return the number of reads in the file (both unaligned and
+	// aligned).
+	//
+	// Input:
+	//   `n_targets`: number of pseudoalignment targets (reference
+	//                sequences). It's not possible to infer this from the Themisto
+	//                file format so has to be provided separately.
+	//   `line`: read each line into this variable.
+	//     NOTE: the contents of the *first* line should already be stored in this variable.
+	//   `stream`: pointer to an istream opened on the pseudoalignment file.
+	//   `ec_configs`: pointer to the output variable that will contain the alignment.
+	// Output:
+	//   `n_reads`: total number of reads in the pseudoalignment (unaligned + aligned).
+	//
+	bm::bvector<>::bulk_insert_iterator it(*ec_configs); // Bulk insert iterator buffers the insertions
+
+	size_t n_reads = 1;
+	try {
+	    // Contents of the first line is already stored in `line`
+	    ReadPlaintextLine(n_targets, line, it);
+
+	    size_t compress_interval = 1000000;
+	    while (std::getline(*stream, line)) {
+		// Insert each line into the alignment
+		ReadPlaintextLine(n_targets, line, it);
+		++n_reads;
+		if (n_reads % compress_interval == 0) {
+		    ec_configs->optimize();
+		}
+	    }
+	} catch (const std::exception &e) {
+	    std::string msg(e.what());
+	    if (msg.find("stoul") != std::string::npos) {
+		throw std::runtime_error("File format not supported on line " + std::to_string(n_reads) + " with content: " + line);
+	    } else {
+		throw std::runtime_error("Could not parse line " + std::to_string(n_reads) + " with content: " + line);
+	    }
+	}
+	return n_reads;
+    }
+
+
+    void read(const std::string &merge_mode, std::vector<std::istream*> &strands) {
+	for (size_t i = 0; i < strands.size(); ++i) {
+	    std::string line;
+	    std::getline(*strands[i], line); // Read the first line to check the format
+	    size_t n_reads;
+	    bm::bvector<> strand_alignment;
+	    if (line.find(',') != std::string::npos) {
+		// First line contains a ','; stream could be in the compact format.
+		size_t n_refs;
+		alignment_writer::ReadHeader(line, &n_reads, &n_refs);
+		if (n_refs > this->n_targets) {
+		    throw std::runtime_error("Pseudoalignment file has more target sequences than expected.");
+		} else if (this->n_targets < n_refs) {
+		    throw std::runtime_error("Pseudoalignment file has less target sequences than expected.");
+		}
+		// Size is given on the header line.
+		strand_alignment.resize(n_reads*n_refs);
+		alignment_writer::UnpackData(strands[i], strand_alignment);
+	    } else {
+		// Stream could be in the plaintext format.
+		// Size is unknown.
+		strand_alignment.set_new_blocks_strat(bm::BM_GAP);
+		n_reads = ReadPlaintextAlignment(n_targets, line, strands[i], &strand_alignment);
+	    }
+	    this->n_queries = n_reads;
+
+	    if (i == 0) {
+		this->bits = std::move(strand_alignment);
+	    } else {
+		if (merge_mode == "intersection") {
+		    this->bits.bit_and(strand_alignment);
+		} else if (merge_mode == "union") {
+		    this->bits.bit_or(strand_alignment);
+		} else {
+		    throw std::runtime_error("Unrecognized option `" + merge_mode + "` for --themisto-mode");
+		}
+	    }
+	}
+    }
+
+    void collapse() {
+	
+    }
+
+    size_t n_ecs() const { return this->n_queries; };
+    size_t n_reads() const { return this->n_queries; };
+    size_t reads_in_ec(const size_t i=0) const { return 1; };
+
+    std::vector<size_t> operator()(const size_t row) const {
+	std::vector<size_t> ret(this->n_groups, 0);
+	for (size_t i = 0; i < this->n_targets; ++i) {
+	    ret[this->group_indicators[i]] += this->bits[row*n_targets + i];
+	}
+	return ret;
+    }
+
+    std::vector<std::vector<uint32_t>> get_aligned_reads() const {
+	std::vector<std::vector<uint32_t>> ret(this->n_queries, std::vector<uint32_t>(1, 0));
+	for (size_t i = 0; i < n_queries; ++i) {
+	    ret[i][0] = i;
+	}
+	return ret;
+    }
+
+    template <typename T>
+    void add_groups(const std::vector<T> &grouping) {
+	size_t _n_groups = 0;
+	this->group_indicators = std::vector<size_t>(grouping.size());
+	for (size_t i = 0; i < grouping.size(); ++i) {
+	    group_indicators[i] = grouping[i];
+	    _n_groups = (n_groups > grouping[i] ? n_groups : grouping[i]);
+	}
+	this->n_groups = _n_groups + 1;
+    }
+
+};
+}
+
+#endif

--- a/include/mSWEEP_alignment.hpp
+++ b/include/mSWEEP_alignment.hpp
@@ -142,11 +142,8 @@ public:
 	}
 #endif
 
-	std::vector<std::unordered_map<size_t, std::pair<size_t, size_t>>> mymap(n_threads);
-	std::vector<std::vector<size_t>> my_ec_counts(n_threads);
-	std::vector<std::vector<std::vector<uint32_t>>> my_ec_read_ids(n_threads);
-	size_t ec_id = 0;
-#pragma omp parallel for schedule(static) firstprivate(ec_id)
+	std::vector<std::unordered_map<size_t, std::vector<uint32_t>>> mymap(n_threads);
+#pragma omp parallel for schedule(static)
 	for (size_t i = 0; i < this->n_queries; ++i) {
 	    if (bits.any_range(i*this->n_targets, (i + 1)*this->n_targets - 1)) {
 		size_t hash = 0;
@@ -157,60 +154,41 @@ public:
 		}
 		auto got = mymap[omp_get_thread_num()].find(hash);
 		if (got == mymap[omp_get_thread_num()].end()) {
-		    mymap[omp_get_thread_num()].insert(std::make_pair(hash, std::make_pair(ec_id, i*this->n_targets)));
-		    my_ec_counts[omp_get_thread_num()].emplace_back(1);
-		    my_ec_read_ids[omp_get_thread_num()].emplace_back(std::vector<uint32_t>({(uint32_t)i}));
-		    ++ec_id;
+		    mymap[omp_get_thread_num()].insert(std::make_pair(hash, std::vector<uint32_t>({(uint32_t)i})));
 		} else {
-		    ++my_ec_counts[omp_get_thread_num()][got->second.first];
-		    my_ec_read_ids[omp_get_thread_num()][got->second.first].emplace_back(i);
+		    got->second.emplace_back(i);
 		}
 	    }
 	}
 
+	std::unordered_map<size_t, std::vector<uint32_t>> map;
+	for (size_t i = 0; i < n_threads; ++i) {
+	    for (auto kv : mymap[i]) {
+		auto got = map.find(kv.first);
+		if (got == map.end()) {
+		    map.insert(std::make_pair(kv.first, std::move(kv.second)));
+		} else {
+		    got->second.insert(got->second.end(),
+				       std::make_move_iterator(kv.second.begin()),
+				       std::make_move_iterator(kv.second.end()));
+		}
+	    }
+	}
+
+	size_t n_ecs = map.size();
+	this->ec_counts = std::vector<size_t>(n_ecs, 0);
+	this->ec_read_ids = std::vector<std::vector<uint32_t>>(n_ecs);
+	size_t i = 0;
 	bm::bvector<> collapsed_bits;
-	if (n_threads == 1) {
-	    this->ec_counts = std::move(my_ec_counts[0]);
-	    this->ec_read_ids = std::move(my_ec_read_ids[0]);
-	    for (auto kv : mymap[0]) {
-		for (size_t k = 0; k < this->n_targets; ++k) {
-		    collapsed_bits[kv.second.first*this->n_targets + k] = bits[kv.second.second + k];
-		}
+	collapsed_bits.resize(n_ecs*this->n_targets);
+	for (auto kv : map) {
+	    this->ec_read_ids[i] = std::move(kv.second);
+	    this->ec_counts[i] = this->ec_read_ids[i].size();
+	    for (size_t k = 0; k < this->n_targets; ++k) {
+		collapsed_bits[i*this->n_targets + k] = this->bits[this->ec_read_ids[i][0]*this->n_targets + k];
 	    }
-	} else {
-	    std::unordered_map<size_t, size_t> map;
-	    size_t j = 0;
-	    for (size_t i = 0; i < n_threads; ++i) {
-		for (auto kv : mymap[i]) {
-		    auto got = map.find(kv.first);
-		    if (got == map.end()) {
-			map.insert(std::make_pair(kv.first, j));
-			// Move leaves the values in my_X indeterminate but that's ok
-			// since each element in my_X is accessed only once
-			this->ec_counts.insert(this->ec_counts.end(),
-					       std::make_move_iterator(my_ec_counts[i].begin() + kv.second.first),
-					       std::make_move_iterator(my_ec_counts[i].begin() + kv.second.first + 1));
-			this->ec_read_ids.emplace_back(std::vector<uint32_t>());
-			this->ec_read_ids.back().insert(this->ec_read_ids.back().end(),
-							std::make_move_iterator(my_ec_read_ids[i][kv.second.first].begin()),
-							std::make_move_iterator(my_ec_read_ids[i][kv.second.first].end()));
-
-			for (size_t k = 0; k < this->n_targets; ++k) {
-			    collapsed_bits[j*this->n_targets + k] = bits[kv.second.second + k];
-			}
-			++j;
-		    } else {
-			// This is where the move would be bad if the elements were accessed more than once
-			this->ec_counts[got->second] += my_ec_counts[i][kv.second.first];
-
-			this->ec_read_ids[got->second].insert(this->ec_read_ids[got->second].end(),
-							      std::make_move_iterator(my_ec_read_ids[i][kv.second.first].begin()),
-							      std::make_move_iterator(my_ec_read_ids[i][kv.second.first].end()));
-		    }
-		}
-	    }
+	    ++i;
 	}
-
 	this->bits = std::move(collapsed_bits);
     }
 

--- a/include/mSWEEP_alignment.hpp
+++ b/include/mSWEEP_alignment.hpp
@@ -153,9 +153,16 @@ public:
 			hash ^= j + 0x517cc1b727220a95 + (hash << 6) + (hash >> 2);
 		    }
 		}
+#if defined(MSWEEP_OPENMP_SUPPORT) && (MSWEEP_OPENMP_SUPPORT) == 1
 		auto got = mymap[omp_get_thread_num()].find(hash);
 		if (got == mymap[omp_get_thread_num()].end()) {
 		    mymap[omp_get_thread_num()].insert(std::make_pair(hash, std::vector<uint32_t>({(uint32_t)i})));
+#else
+		auto got = mymap[0].find(hash);
+		if (got == mymap[0].end()) {
+		    mymap[0].insert(std::make_pair(hash, std::vector<uint32_t>({(uint32_t)i})));
+
+#endif
 		} else {
 		    got->second.emplace_back(i);
 		}
@@ -185,7 +192,10 @@ public:
 #pragma omp parallel
 	{
 	    size_t i = 0;
-	    size_t thread_id = omp_get_thread_num();
+	    size_t thread_id = 0;
+#if defined(MSWEEP_OPENMP_SUPPORT) && (MSWEEP_OPENMP_SUPPORT) == 1
+	    thread_id = omp_get_thread_num();
+#endif
 	    collapsed_bits[thread_id].resize(n_ecs*this->n_targets);
 	    for(auto element = map.begin(); element !=map.end(); ++element, i++) {
 		if(i%n_threads == thread_id) {

--- a/include/mSWEEP_openmp_config.hpp.in
+++ b/include/mSWEEP_openmp_config.hpp.in
@@ -33,6 +33,9 @@
 #pragma omp declare reduction(vec_double_plus : std::vector<double> :	\
                               std::transform(omp_out.begin(), omp_out.end(), omp_in.begin(), omp_out.begin(), std::plus<double>())) \
                     initializer(omp_priv = decltype(omp_orig)(omp_orig.size()))
+#pragma omp declare reduction(vec_size_t_plus : std::vector<size_t> :	\
+                              std::transform(omp_out.begin(), omp_out.end(), omp_in.begin(), omp_out.begin(), std::plus<size_t>())) \
+                    initializer(omp_priv = decltype(omp_orig)(omp_orig.size()))
 #endif
 
 

--- a/src/BootstrapSample.cpp
+++ b/src/BootstrapSample.cpp
@@ -30,7 +30,7 @@
 #include "mSWEEP_version.h"
 
 namespace mSWEEP {
-void BootstrapSample::init_bootstrap(const telescope::Alignment &alignment) {
+void BootstrapSample::init_bootstrap(const mSWEEP::Alignment &alignment) {
   // Clear the bootstrap abundances in case we're estimating the same sample again.
   this->bootstrap_results = std::vector<std::vector<double>>();
 
@@ -43,7 +43,7 @@ void BootstrapSample::init_bootstrap(const telescope::Alignment &alignment) {
   ec_distribution = std::discrete_distribution<uint32_t>(weights.begin(), weights.end());
 }
 
-void BootstrapSample::construct(const telescope::Alignment &alignment, const size_t _iters, const int32_t seed, const size_t _bootstrap_count) {
+void BootstrapSample::construct(const mSWEEP::Alignment &alignment, const size_t _iters, const int32_t seed, const size_t _bootstrap_count) {
   this->count_alignments(alignment);
   if (seed == 26012023) {
     std::random_device rd;

--- a/src/Sample.cpp
+++ b/src/Sample.cpp
@@ -27,7 +27,7 @@
 #include <exception>
 
 namespace mSWEEP {
-void ConstructSample(const telescope::Alignment &alignment, const size_t bootstrap_iters, const size_t bootstrap_count, const size_t bootstrap_seed, const bool bin_reads, std::unique_ptr<Sample> &sample) {
+void ConstructSample(const mSWEEP::Alignment &alignment, const size_t bootstrap_iters, const size_t bootstrap_count, const size_t bootstrap_seed, const bool bin_reads, std::unique_ptr<Sample> &sample) {
   // Wrapper for determining which Sample type to construct.
   // Initialize Sample depending on how the alignment needs to be processed.
   if (bootstrap_iters > 0) {
@@ -49,7 +49,7 @@ void ConstructSample(const telescope::Alignment &alignment, const size_t bootstr
   }
 }
 
-void Sample::count_alignments(const telescope::Alignment &alignment) {
+void Sample::count_alignments(const mSWEEP::Alignment &alignment) {
   // Count the number of aligned reads and store in counts_total
   size_t aln_counts_total = 0;
 #pragma omp parallel for schedule(static) reduction(+:aln_counts_total)

--- a/src/mSWEEP.cpp
+++ b/src/mSWEEP.cpp
@@ -353,6 +353,7 @@ int main (int argc, char *argv[]) {
 	  }
 
 	  alignment.read(args.value<std::string>("themisto-mode"), strands);
+	  alignment.collapse();
 
 	} catch (std::exception &e) {
 	  finalize("Reading the pseudoalignments failed:\n  " + std::string(e.what()) + "\nexiting\n", log, true);

--- a/src/mSWEEP.cpp
+++ b/src/mSWEEP.cpp
@@ -353,7 +353,10 @@ int main (int argc, char *argv[]) {
 	  }
 
 	  alignment.read(args.value<std::string>("themisto-mode"), strands);
+	  log << "  read alignments for " << alignment.n_reads() << " reads" << '\n';
+	  log << "Building equivalence classes" << '\n';
 	  alignment.collapse();
+	  log << "  found " << alignment.n_ecs() << " unique alignments" << '\n';
 
 	} catch (std::exception &e) {
 	  finalize("Reading the pseudoalignments failed:\n  " + std::string(e.what()) + "\nexiting\n", log, true);
@@ -363,6 +366,7 @@ int main (int argc, char *argv[]) {
 	// Use the alignment data to populate the log_likelihoods matrix.
 	try {
 	    // Read the pseudoalignment
+	    log << "Computing the likelihood matrix" << '\n';
 	    if (n_groups <= std::numeric_limits<uint8_t>::max()) {
 		alignment.add_groups(static_cast<const mSWEEP::AdaptiveReference<uint8_t>*>(&(*reference))->get_group_indicators(i));
 	    } else if (n_groups <= std::numeric_limits<uint16_t>::max()) {
@@ -383,7 +387,6 @@ int main (int argc, char *argv[]) {
 	// Note: this is also only used by the root process in MPI configuration.
 	mSWEEP::ConstructSample(alignment, args.value<size_t>("iters"), args.value<size_t>("bootstrap-count"), args.value<size_t>("seed"), bin_reads, sample);
 
-	log << "  read " << alignment.n_ecs() << " unique alignments" << '\n';
 	log.flush();
       } else {
 	try {


### PR DESCRIPTION
- Can now scale to inputs that are ~ 100 million queries x 50 000 targets in size.
- Remove dependency on telescope.
- More fixes related to parallelism in the input reading and likelihood construction phase.